### PR TITLE
feat: remove useless linear ticket section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,5 @@
 # PR Overview
 
-## Ticket Reference
-[Linear Ticket URL]()
-
 ## Context
 _Briefly describe the purpose of this PR._
 


### PR DESCRIPTION
# PR Overview

## Context
When creating a PR linked to a linear ticket, linear bot will already provide in the PR comments the ticket link and content, so no need to ask it here.
If the PR is not linked to a ticket, then Context section will be sufficient.